### PR TITLE
add support for hostnames with numbers

### DIFF
--- a/datadog-notify
+++ b/datadog-notify
@@ -9,7 +9,7 @@ function usage(){
   echo "  tags:    Optional tags in key:vaule format  ie. 'app:foo group:bar" >&2
   echo >&2
   echo "Examples:" >&2
-  echo "$0 'Test Event' 'This event is just for testing' 'test:true foo:bar'" >&2
+  echo "$0 'Test Event' 'This event is just for testing' info 'test:true foo:bar'" >&2
   echo "$0 'Another Event' 'This event is just for testing'" >&2
   exit 1
 }
@@ -48,7 +48,7 @@ if $(echo "$alert_type" | grep -qv 'error\|warning\|info\|success' ); then
 fi
 
 tag="environment:$(hostname) $4"
-tags=$(echo $tag | sed -e's/[\.a-zA-Z:]*/\"&\"/g' -e's/\" \"/\", \"/g' )
+tags=$(echo $tag | sed -e's/[\.a-zA-Z:0-9]*/\"&\"/g' -e's/\" \"/\", \"/g' )
 
 api="https://app.datadoghq.com/api/v1"
 datadog="${api}/events?api_key=${api_key}"


### PR DESCRIPTION
current sed expression only takes into consideration letters in the hostname part.

```
tag="environment:$(hostname) $4"
tags=$(echo $tag | sed -e's/[\.a-zA-Z:0-9]*/\"&\"/g' -e's/\" \"/\", \"/g' )
echo '-----'
echo $tag
echo '-----'
echo $tags
```

```
./datadog-notify 'Test Event' 'This event is just for testing' info 'test:true foo:bar'
```
will produce the following output
```
-----
environment:webserver1 test:true foo:bar
-----
"environment:webserver"1"", "test:true", "foo:bar"
```
```

Also updated the help message, adding the `type` in the first example, otherwise it will fail:
```
$ ../datadog-notify 'Test Event' 'This event is just for testing'  'test:true foo:bar'
Failed: alert_type was 'test:true foo:bar', needs to be one of 'success', 'info', 'error' or 'warning'
```