### PR TITLE
fix: replace newline char with space

### DIFF
--- a/datadog-notify
+++ b/datadog-notify
@@ -65,4 +65,4 @@ EOJ
 
 #echo -e "$payload"
 
-curl -s -X POST -H "Content-type: application/json" -d "$payload" "$datadog"
+curl -s -X POST -H "Content-type: application/json" -d "$(echo "${payload}" | sed ':a;N;$!ba;s/\n/ /g')" "$datadog"


### PR DESCRIPTION
Spaces in the json payload cause Datadog to misinterpret it as malformed.
Added a sed to replace all the newlines with space characters